### PR TITLE
fix: remove usePathname from nav to fix scroll jump on parlementaire

### DIFF
--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -125,3 +125,64 @@ body {
   color: var(--color-foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Active states for PouvoirSelector and NavigationParlementaire — driven by hidden data
+   markers on the current page so no client-side JS or usePathname() is needed. */
+
+/* ── PouvoirSelector ──────────────────────────────────────────────────── */
+.pouvoirs-wrapper:has([data-current-pouvoir="executif"]) [data-nav-pouvoir="executif"],
+.pouvoirs-wrapper:has([data-current-pouvoir="parlementaire"]) [data-nav-pouvoir="parlementaire"],
+.pouvoirs-wrapper:has([data-current-pouvoir="local"]) [data-nav-pouvoir="local"],
+.pouvoirs-wrapper:has([data-current-pouvoir="autres"]) [data-nav-pouvoir="autres"],
+.pouvoirs-wrapper:has([data-current-pouvoir="monde"]) [data-nav-pouvoir="monde"] {
+  border-color: var(--color-foundations-violet-principal);
+  background-color: var(--color-foundations-violet-principal);
+
+  & svg {
+    fill: white;
+  }
+
+  & .nav-text {
+    color: white;
+  }
+}
+
+/* ── NavigationParlementaire ──────────────────────────────────────────── */
+
+/* Active card styling */
+.pouvoirs-wrapper:has([data-current-parlement="assemblee-nationale"]) [data-nav-parlement="assemblee-nationale"] .nav-parlement-card,
+.pouvoirs-wrapper:has([data-current-parlement="senat"]) [data-nav-parlement="senat"] .nav-parlement-card,
+.pouvoirs-wrapper:has([data-current-parlement="parlement-europeen"]) [data-nav-parlement="parlement-europeen"] .nav-parlement-card {
+  background-color: var(--color-foundations-blanc);
+  border-bottom-width: 4px;
+  border-left-width: 0;
+
+  & .nav-icon-desktop {
+    display: block;
+  }
+
+  & .nav-arrow-bottom {
+    display: block;
+  }
+
+  & .nav-arrow-left {
+    display: none;
+  }
+}
+
+/* Mobile active section: hide all items by default, show only the current one */
+.parlement-active-section [data-nav-parlement] {
+  display: none;
+}
+.pouvoirs-wrapper:has([data-current-parlement="assemblee-nationale"]) .parlement-active-section [data-nav-parlement="assemblee-nationale"],
+.pouvoirs-wrapper:has([data-current-parlement="senat"]) .parlement-active-section [data-nav-parlement="senat"],
+.pouvoirs-wrapper:has([data-current-parlement="parlement-europeen"]) .parlement-active-section [data-nav-parlement="parlement-europeen"] {
+  display: block;
+}
+
+/* Mobile inactive section: hide the active item */
+.pouvoirs-wrapper:has([data-current-parlement="assemblee-nationale"]) .parlement-inactive-section [data-nav-parlement="assemblee-nationale"],
+.pouvoirs-wrapper:has([data-current-parlement="senat"]) .parlement-inactive-section [data-nav-parlement="senat"],
+.pouvoirs-wrapper:has([data-current-parlement="parlement-europeen"]) .parlement-inactive-section [data-nav-parlement="parlement-europeen"] {
+  display: none;
+}

--- a/nextjs/src/app/pouvoirs/autres/page.tsx
+++ b/nextjs/src/app/pouvoirs/autres/page.tsx
@@ -2,7 +2,7 @@ import { PageTitle } from "@/components/titles";
 
 export default function Page() {
   return (
-    <div>
+    <div data-current-pouvoir="autres">
       <PageTitle title="Autres pouvoirs" subtitle="Texte à ajouter" />
     </div>
   );

--- a/nextjs/src/app/pouvoirs/executif/page.tsx
+++ b/nextjs/src/app/pouvoirs/executif/page.tsx
@@ -9,7 +9,7 @@ const { composantes, score } = pouvoirData.executif;
 
 export default function Page() {
   return (
-    <>
+    <div className="contents" data-current-pouvoir="executif">
       <PageTitle title="Pouvoir éxécutif" subtitle="Texte à ajouter" />
       <Hero>
         <PouvoirFigureXL
@@ -64,6 +64,6 @@ export default function Page() {
           pourcentage={composantes.directrices_cabinet_gouvernement.score}
         />
       </div>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/app/pouvoirs/layout.tsx
+++ b/nextjs/src/app/pouvoirs/layout.tsx
@@ -1,123 +1,20 @@
-"use client";
-import Link, { type LinkProps } from "next/link";
-import { usePathname } from "next/navigation";
-import type { HTMLAttributes, JSX } from "react";
-import { MondeIcon } from "@/components/icons/monde";
-import { AutresPouvoirsIcon } from "@/components/icons/pouvoir-autres";
-import { PouvoirExecutifIcon } from "@/components/icons/pouvoir-executif";
-import { PouvoirLocalIcon } from "@/components/icons/pouvoir-local";
-import { PouvoirParlementaireIcon } from "@/components/icons/pouvoir-parlementaire";
-import { cn } from "@/lib/utils";
+import { PouvoirSelectorNav } from "@/components/PouvoirSelector";
 
 export default function PouvoirLayout({
-  children,
+	children,
 }: Readonly<{
-  children: React.ReactNode;
+	children: React.ReactNode;
 }>) {
-  return (
-    <div>
-      <div className="flex flex-1 justify-center px-4 bg-purple-oxfam-100 ">
-        <div className="flex flex-col gap-4 max-w-296 items-center  py-12 md:items-start ">
-          <div className="flex flex-wrap justify-center gap-4 mt-4">
-            <PouvoirSelector
-              title={
-                <>
-                  Pouvoir
-                  <br /> exécutif
-                </>
-              }
-              icon={PouvoirExecutifIcon}
-              href="/pouvoirs/executif"
-            />
-            <PouvoirSelector
-              title={
-                <>
-                  Pouvoir
-                  <br /> parlementaire
-                </>
-              }
-              icon={PouvoirParlementaireIcon}
-              href="/pouvoirs/parlementaire"
-            />
-            <PouvoirSelector
-              title={
-                <>
-                  Pouvoir
-                  <br /> local
-                </>
-              }
-              icon={PouvoirLocalIcon}
-              href="/pouvoirs/local"
-            />
-            <PouvoirSelector
-              title={
-                <>
-                  Autres
-                  <br /> pouvoirs
-                </>
-              }
-              icon={AutresPouvoirsIcon}
-              href="/pouvoirs/autres"
-            />
-            <PouvoirSelector
-              title={
-                <>
-                  Dans le
-                  <br /> monde
-                </>
-              }
-              icon={MondeIcon}
-              href="/pouvoirs/monde"
-            />
-          </div>
-        </div>
-      </div>
-      <div className="flex flex-col mt-20 gap-8  items-center justify-center ">
-        {children}
-      </div>
-    </div>
-  );
+	return (
+		<div className="pouvoirs-wrapper">
+			<div className="flex flex-1 justify-center px-4 bg-purple-oxfam-100 ">
+				<div className="flex flex-col gap-4 max-w-296 items-center  py-12 md:items-start ">
+					<PouvoirSelectorNav />
+				</div>
+			</div>
+			<div className="flex flex-col mt-20 gap-8  items-center justify-center ">
+				{children}
+			</div>
+		</div>
+	);
 }
-
-type PouvoirSelectorProps = LinkProps & {
-  title: React.ReactNode;
-  icon: (props: HTMLAttributes<HTMLOrSVGElement>) => JSX.Element;
-};
-const PouvoirSelector = ({
-  title,
-  icon: Icon,
-  ...linkProps
-}: PouvoirSelectorProps) => {
-  const pathname = usePathname().replace(/\/$/, "");
-
-  return (
-    <Link
-      className={cn(
-        "flex-1 flex flex-col justify-center items-center p-2 gap-2 w-44 h-44 text-center",
-        "border border-purple-oxfam-100 flex-none self-stretch",
-        "bg-foundations-blanc",
-        "hover:border hover:border-foundations-violet-principal hover:bg-foundations-violet-principal",
-        "group bg-svg-inequal",
-        pathname === linkProps.href &&
-          "border-foundations-violet-principal bg-foundations-violet-principal",
-      )}
-      {...linkProps}
-    >
-      <Icon
-        className={cn(
-          "w-18 h-18 group-hover:fill-white",
-          pathname === linkProps.href && "fill-white",
-        )}
-      />
-
-      <div
-        className={cn(
-          "text-center header-h4 group-hover:text-white whitespace-break-spaces w-full",
-          pathname === linkProps.href && "text-white",
-        )}
-      >
-        {title}
-      </div>
-    </Link>
-  );
-};

--- a/nextjs/src/app/pouvoirs/local/page.tsx
+++ b/nextjs/src/app/pouvoirs/local/page.tsx
@@ -56,7 +56,7 @@ export default async function Page() {
   const dataPerRegion = { ...dataPerRegionMetropole, ...dataPerRegionOutreMer };
 
   return (
-    <>
+    <div className="contents" data-current-pouvoir="local">
       <PageTitle title="Pouvoir local" subtitle="Texte à ajouter" />
       <Hero>
         <PouvoirFigureXL
@@ -193,6 +193,6 @@ export default async function Page() {
           />
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/app/pouvoirs/monde/page.tsx
+++ b/nextjs/src/app/pouvoirs/monde/page.tsx
@@ -2,7 +2,7 @@ import { PageTitle } from "@/components/titles";
 
 export default function Page() {
   return (
-    <div>
+    <div data-current-pouvoir="monde">
       <PageTitle title="Dans le monde" subtitle="Texte à ajouter" />
     </div>
   );

--- a/nextjs/src/app/pouvoirs/parlementaire/assemblee-nationale/page.tsx
+++ b/nextjs/src/app/pouvoirs/parlementaire/assemblee-nationale/page.tsx
@@ -10,7 +10,7 @@ const { annee, score, composantes } =
 
 export default function Page() {
   return (
-    <>
+    <div className="contents" data-current-parlement="assemblee-nationale">
       <SectionTitle title="Assemblée Nationale" />
       <div className="mt-8 max-w-4xl flex flex-col items-center justify-center gap-4 mb-12">
         <div className="w-full lg:w-lg">
@@ -53,6 +53,6 @@ export default function Page() {
           />
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/app/pouvoirs/parlementaire/layout.tsx
+++ b/nextjs/src/app/pouvoirs/parlementaire/layout.tsx
@@ -19,7 +19,7 @@ export default function PouvoirLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <>
+    <div className="contents" data-current-pouvoir="parlementaire">
       <PageTitle title="Pouvoir parlementaire" subtitle="Texte à ajouter" />
       <Hero>
         <PouvoirFigureXL
@@ -74,21 +74,24 @@ export default function PouvoirLayout({
             label: "Assemblée Nationale",
             href: "/pouvoirs/parlementaire/assemblee-nationale",
             icon: <AssembleeNationaleIcon />,
+            parlementKey: "assemblee-nationale",
           },
           {
             label: "Sénat",
             href: "/pouvoirs/parlementaire/senat",
             icon: <SénatIcon />,
+            parlementKey: "senat",
           },
           {
             label: "Parlement Européen",
             href: "/pouvoirs/parlementaire/parlement-europeen",
             icon: <ParlementEuropéenIcon />,
+            parlementKey: "parlement-europeen",
           },
         ]}
       >
         {children}
       </NavigationParlementaireSection>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/app/pouvoirs/parlementaire/parlement-europeen/page.tsx
+++ b/nextjs/src/app/pouvoirs/parlementaire/parlement-europeen/page.tsx
@@ -8,7 +8,7 @@ const { annee, score } = parlementaire.composantes.europeen;
 
 export default function Page() {
   return (
-    <>
+    <div className="contents" data-current-parlement="parlement-europeen">
       <SectionTitle title="Parlement Européen" />
       <div className="mt-8 max-w-4xl flex flex-col items-center justify-center gap-4 mb-12">
         <div className="w-full lg:w-lg">
@@ -32,6 +32,6 @@ export default function Page() {
           </p>
         </InfoBox>
       </div>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/app/pouvoirs/parlementaire/senat/page.tsx
+++ b/nextjs/src/app/pouvoirs/parlementaire/senat/page.tsx
@@ -9,7 +9,7 @@ const { annee, score, composantes } = parlementaire.composantes.senat;
 
 export default function Page() {
   return (
-    <>
+    <div className="contents" data-current-parlement="senat">
       <SectionTitle title="Sénat" />
       <div className="mt-8 max-w-4xl flex flex-col items-center justify-center gap-4  mb-12">
         <div className="w-full lg:w-lg">
@@ -53,6 +53,6 @@ export default function Page() {
           />
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/nextjs/src/components/NavigationParlementaire.tsx
+++ b/nextjs/src/components/NavigationParlementaire.tsx
@@ -1,46 +1,34 @@
-"use client";
-
 import type { LinkProps } from "next/link";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
 
 type NavigationParlementaireProps = {
-  label: string;
-  href: LinkProps["href"];
-  icon: React.ReactNode;
+	label: string;
+	href: LinkProps["href"];
+	icon: React.ReactNode;
+	parlementKey: string;
 };
+
 export const NavigationParlementaire = ({
-  label,
-  href,
-  icon,
+	label,
+	href,
+	icon,
+	parlementKey,
 }: NavigationParlementaireProps) => {
-  const pathname = usePathname().replace(/\/$/, "");
-  const isActive = pathname === href;
-  return (
-    <Link href={href}>
-      <div
-        className={cn(
-          `flex flex-row lg:flex-col justify-between lg:justify-center items-center px-6 py-2 gap-3 rounded min-h-20 w-full lg:w-44 relative`,
-          "border-foundations-violet-principal",
-          isActive
-            ? "bg-foundations-blanc border-b-4"
-            : "bg-foundations-violet-tres-clair border-l-4 lg:border-l-0",
-        )}
-      >
-        <h4 className="header-h4 text-center">{label}</h4>
+	return (
+		<Link href={href} data-nav-parlement={parlementKey}>
+			<div className="nav-parlement-card flex flex-row lg:flex-col justify-between lg:justify-center items-center px-6 py-2 gap-3 rounded min-h-20 w-full lg:w-44 relative border-foundations-violet-principal bg-foundations-violet-tres-clair border-l-4 lg:border-l-0">
+				<h4 className="header-h4 text-center">{label}</h4>
 
-        {/* the icon only shows when active on large screens, but always on small screens */}
-        {isActive && <div className="hidden lg:block">{icon}</div>}
-        <div className="lg:hidden">{icon}</div>
+				{/* Desktop icon: hidden by default, shown when active via CSS */}
+				<div className="nav-icon-desktop hidden">{icon}</div>
+				{/* Mobile icon: always shown */}
+				<div className="lg:hidden">{icon}</div>
 
-        {isActive && (
-          <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-10 border-r-10 border-t-10 border-l-transparent border-r-transparent border-t-foundations-violet-principal" />
-        )}
-        {!isActive && (
-          <div className="lg:hidden absolute left-0 top-1/2 -translate-y-1/2 w-0 h-0 border-t-10 border-b-10 border-l-10 border-t-transparent border-b-transparent border-l-foundations-violet-principal" />
-        )}
-      </div>
-    </Link>
-  );
+				{/* Bottom arrow: shown when active via CSS */}
+				<div className="nav-arrow-bottom hidden absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-10 border-r-10 border-t-10 border-l-transparent border-r-transparent border-t-foundations-violet-principal" />
+				{/* Left arrow: shown on mobile for inactive items, hidden when active via CSS */}
+				<div className="nav-arrow-left lg:hidden absolute left-0 top-1/2 -translate-y-1/2 w-0 h-0 border-t-10 border-b-10 border-l-10 border-t-transparent border-b-transparent border-l-foundations-violet-principal" />
+			</div>
+		</Link>
+	);
 };

--- a/nextjs/src/components/NavigationParlementaireSection.tsx
+++ b/nextjs/src/components/NavigationParlementaireSection.tsx
@@ -1,74 +1,70 @@
-"use client";
-
-import { usePathname } from "next/navigation";
 import { NavigationParlementaire } from "./NavigationParlementaire";
 
 type NavItem = {
-  label: string;
-  href: string;
-  icon: React.ReactNode;
+	label: string;
+	href: string;
+	icon: React.ReactNode;
+	parlementKey: string;
 };
 
 type Props = {
-  navItems: NavItem[];
-  children: React.ReactNode;
+	navItems: NavItem[];
+	children: React.ReactNode;
 };
 
 export const NavigationParlementaireSection = ({
-  navItems,
-  children,
+	navItems,
+	children,
 }: Props) => {
-  const pathname = usePathname().replace(/\/$/, "");
-  const activeItem = navItems.find((item) => item.href === pathname);
-  const inactiveItems = navItems.filter((item) => item.href !== pathname);
+	return (
+		<>
+			{/* Purple banner - always shown. Desktop: navs are absolutely positioned inside. */}
+			<div className="w-full lg:relative flex flex-col items-center justify-start lg:mb-38">
+				<div className="w-full bg-foundations-violet-principal h-28 flex items-center lg:items-start lg:py-6 justify-center">
+					<div className="body4-medium text-foundations-blanc">
+						Les chiffres en détails
+					</div>
+				</div>
+				<div className="hidden lg:flex lg:absolute top-20 flex-row w-auto gap-4">
+					{navItems.map((item) => (
+						<NavigationParlementaire
+							key={item.href}
+							label={item.label}
+							href={item.href}
+							icon={item.icon}
+							parlementKey={item.parlementKey}
+						/>
+					))}
+				</div>
+			</div>
 
-  return (
-    <>
-      {/* Purple banner - always shown. Desktop: navs are absolutely positioned inside. */}
-      <div className="w-full lg:relative flex flex-col items-center justify-start lg:mb-38">
-        <div className="w-full bg-foundations-violet-principal h-28 flex items-center lg:items-start lg:py-6 justify-center">
-          <div className="body4-medium text-foundations-blanc">
-            Les chiffres en détails
-          </div>
-        </div>
-        <div className="hidden lg:flex lg:absolute top-20 flex-row w-auto gap-4">
-          {navItems.map((item) => (
-            <NavigationParlementaire
-              key={item.href}
-              label={item.label}
-              href={item.href}
-              icon={item.icon}
-            />
-          ))}
-        </div>
-      </div>
+			{/* Mobile: all items rendered here, CSS shows only the active one above children */}
+			<div className="parlement-active-section lg:hidden flex flex-col w-full">
+				{navItems.map((item) => (
+					<NavigationParlementaire
+						key={item.href}
+						label={item.label}
+						href={item.href}
+						icon={item.icon}
+						parlementKey={item.parlementKey}
+					/>
+				))}
+			</div>
 
-      {/* Mobile: active nav above children */}
-      {activeItem && (
-        <div className="lg:hidden w-full">
-          <NavigationParlementaire
-            label={activeItem.label}
-            href={activeItem.href}
-            icon={activeItem.icon}
-          />
-        </div>
-      )}
+			{children}
 
-      {children}
-
-      {/* Mobile: inactive navs below children */}
-      {inactiveItems.length > 0 && (
-        <div className="lg:hidden flex flex-col gap-4 w-full">
-          {inactiveItems.map((item) => (
-            <NavigationParlementaire
-              key={item.href}
-              label={item.label}
-              href={item.href}
-              icon={item.icon}
-            />
-          ))}
-        </div>
-      )}
-    </>
-  );
+			{/* Mobile: all items rendered here, CSS hides the active one leaving only inactive items */}
+			<div className="parlement-inactive-section lg:hidden flex flex-col gap-4 w-full">
+				{navItems.map((item) => (
+					<NavigationParlementaire
+						key={item.href}
+						label={item.label}
+						href={item.href}
+						icon={item.icon}
+						parlementKey={item.parlementKey}
+					/>
+				))}
+			</div>
+		</>
+	);
 };

--- a/nextjs/src/components/PouvoirSelector.tsx
+++ b/nextjs/src/components/PouvoirSelector.tsx
@@ -1,0 +1,95 @@
+import Link, { type LinkProps } from "next/link";
+import type { HTMLAttributes, JSX } from "react";
+import { MondeIcon } from "@/components/icons/monde";
+import { AutresPouvoirsIcon } from "@/components/icons/pouvoir-autres";
+import { PouvoirExecutifIcon } from "@/components/icons/pouvoir-executif";
+import { PouvoirLocalIcon } from "@/components/icons/pouvoir-local";
+import { PouvoirParlementaireIcon } from "@/components/icons/pouvoir-parlementaire";
+
+type PouvoirSelectorProps = LinkProps & {
+	title: React.ReactNode;
+	icon: (props: HTMLAttributes<HTMLOrSVGElement>) => JSX.Element;
+	pouvoirKey: string;
+};
+
+const PouvoirSelector = ({
+	title,
+	icon: Icon,
+	pouvoirKey,
+	...linkProps
+}: PouvoirSelectorProps) => {
+	return (
+		<Link
+			className="flex-1 flex flex-col justify-center items-center p-2 gap-2 w-44 h-44 text-center border border-purple-oxfam-100 flex-none self-stretch bg-foundations-blanc hover:border hover:border-foundations-violet-principal hover:bg-foundations-violet-principal group bg-svg-inequal"
+			data-nav-pouvoir={pouvoirKey}
+			{...linkProps}
+		>
+			<Icon className="w-18 h-18 group-hover:fill-white" />
+			<div className="nav-text text-center header-h4 group-hover:text-white whitespace-break-spaces w-full">
+				{title}
+			</div>
+		</Link>
+	);
+};
+
+export function PouvoirSelectorNav() {
+	return (
+		<div className="flex flex-wrap justify-center gap-4 mt-4">
+			<PouvoirSelector
+				title={
+					<>
+						Pouvoir
+						<br /> exécutif
+					</>
+				}
+				icon={PouvoirExecutifIcon}
+				href="/pouvoirs/executif"
+				pouvoirKey="executif"
+			/>
+			<PouvoirSelector
+				title={
+					<>
+						Pouvoir
+						<br /> parlementaire
+					</>
+				}
+				icon={PouvoirParlementaireIcon}
+				href="/pouvoirs/parlementaire"
+				pouvoirKey="parlementaire"
+			/>
+			<PouvoirSelector
+				title={
+					<>
+						Pouvoir
+						<br /> local
+					</>
+				}
+				icon={PouvoirLocalIcon}
+				href="/pouvoirs/local"
+				pouvoirKey="local"
+			/>
+			<PouvoirSelector
+				title={
+					<>
+						Autres
+						<br /> pouvoirs
+					</>
+				}
+				icon={AutresPouvoirsIcon}
+				href="/pouvoirs/autres"
+				pouvoirKey="autres"
+			/>
+			<PouvoirSelector
+				title={
+					<>
+						Dans le
+						<br /> monde
+					</>
+				}
+				icon={MondeIcon}
+				href="/pouvoirs/monde"
+				pouvoirKey="monde"
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- `PouvoirSelector` and `NavigationParlementaire` were `"use client"` solely because of `usePathname()`, which caused a scroll jump when navigating into the parlementaire nested layout
- Active state is now driven entirely by CSS `:has()` — each page sets a `data-current-pouvoir` / `data-current-parlement` attribute on its root element, and nav items respond via matching `data-nav-*` attributes
- No client-side JS involved; `pouvoirs/layout.tsx`, `PouvoirSelector.tsx`, `NavigationParlementaire.tsx`, and `NavigationParlementaireSection.tsx` are all now pure server components

## Test plan

- [ ] Navigate from any section (executif, local…) to parlementaire — verify no scroll jump
- [ ] Navigate within parlementaire sub-pages (Assemblée Nationale → Sénat → Parlement Européen) — verify scroll is preserved and no jump
- [ ] Verify active state highlights the correct tile in `PouvoirSelectorNav` on each section
- [ ] Verify active state highlights the correct item in `NavigationParlementaireSection` on each sub-page
- [ ] Check mobile layout: active nav item appears above page content, inactive items below
- [ ] Check desktop layout: all nav cards shown in the purple banner area, active card styled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)