### PR TITLE
Support older Safari via browserslist config

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -34,5 +34,9 @@
   },
   "engines": {
     "node": "^24"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "safari >= 14"
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds `browserslist` to `package.json` so Next.js/SWC transpiles modern JS syntax (static class initialization blocks, required Safari 16.4+) down to Safari 14+
- Uses `defaults, safari >= 14` — only ~6 KB bundle size overhead over no config
- Covers ~1.22% of French users on older Safari versions

## Test plan

- [ ] Verify the site loads correctly on Safari 14/15
- [ ] Check bundle size hasn't regressed significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)